### PR TITLE
add test coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 build
+coverage
 .env
 .vscode

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:coverage": "react-scripts test --coverage --watchAll=false",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
In order to address https://github.com/aamay001/react-resume/issues/36, I was thinking of taking a stab at adding some tests, but I thought I would start by adding a coverage script and some documentation to the README. With this PR, you can run:

```
npm run test:coverage
```

And then view the coverage in a browser:

```
open coverage/lcov-report/index.html
```

Which currently looks like:

![image](https://user-images.githubusercontent.com/173215/67256839-15684d80-f457-11e9-9f20-fc338d689e6d.png)

This might help contributors determine which areas of the code need tests. 