### PR TITLE
Add Cypress tests for the font selector

### DIFF
--- a/cypress/integration/components/Tools/FontSelector.spec.js
+++ b/cypress/integration/components/Tools/FontSelector.spec.js
@@ -1,0 +1,29 @@
+/// <reference types="cypress" />
+
+context('Font Selector', () => {
+  beforeEach(() => {
+    // visit baseURL (cypress.json)
+    cy.visit('/');
+
+    cy.get('[data-cy=font-selector]').as('fontSelector');
+  });
+
+  it('should display a select element', () => {
+    cy.get('@fontSelector').should('be.visible');
+  });
+
+  it('changes the font of the resume when a font is selected', () => {
+    const fontLabel = 'Arimo';
+    const fontStyle = 'Arimo, sans-serif';
+
+    cy.get('.resume').as('resume');
+
+    cy.get('@resume').should('not.have.css', 'font-family', fontStyle);
+
+    cy.get('@fontSelector')
+        .select(fontLabel)
+        .should('have.value', fontStyle);
+
+    cy.get('@resume').should('have.css', 'font-family', fontStyle);
+  })
+});

--- a/src/components/Tools/FontSelector.js
+++ b/src/components/Tools/FontSelector.js
@@ -38,6 +38,7 @@ class FontSelector extends Component {
         >
           <select
             className="options-selector"
+            data-cy="font-selector"
             onChange={this.handleFontChange}
             value={selectedFont}
           >


### PR DESCRIPTION
There now is a cypress test for the font selector. The test checks if the resume font changes when the user selects a font from the form selector.