### PR TITLE
[Tests] Add test for LocalStorageToggle button

### DIFF
--- a/cypress/integration/components/Tools/Buttons/LocalStorageToggle.spec.js
+++ b/cypress/integration/components/Tools/Buttons/LocalStorageToggle.spec.js
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+
+const defaultValues = {
+  autoSave: false,
+  autoSaveOnToast: ' 💾 Auto save to local storage is now on!',
+  autoSaveOffToast: ' ⚠️ Auto save to local storage is now off!',
+};
+
+context('Auto Save to Local Storage Button', () => {
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should toggle auto save to local storage button', () => {
+    cy.get('[data-testid=autoSave]').click();
+    cy.get('[data-testid=autoSave] > div').should((!defaultValues.autoSave ? '' : 'not.') + 'have.class', 'checked');
+    cy.get('.Toastify__toast-container')
+      .should('be.visible')
+      .contains(!defaultValues.autoSave ? defaultValues.autoSaveOnToast : defaultValues.autoSaveOffToast);
+
+    cy.get('[data-testid=autoSave]').click();
+    cy.get('[data-testid=autoSave] > div').should((defaultValues.autoSave ? '' : 'not.') + 'have.class', 'checked');
+    cy.get('.Toastify__toast-container')
+      .should('be.visible')
+      .contains(defaultValues.autoSave ? defaultValues.autoSaveOnToast : defaultValues.autoSaveOffToast);
+  });
+});


### PR DESCRIPTION
### This PR adds test on LocalStorageToggle :
- asserts toggle button is working
- asserts respective messages pops up

- [x] Tested locally
![c00](https://user-images.githubusercontent.com/52366632/94990409-8c7cf000-059b-11eb-9d12-45cb9e574cde.JPG)

closes #81 