### PR TITLE
[Tests] Pass LocalStorageToggle test when default autoSave value changes

### DIFF
--- a/cypress/integration/components/Tools/Buttons/LocalStorageToggle.spec.js
+++ b/cypress/integration/components/Tools/Buttons/LocalStorageToggle.spec.js
@@ -9,6 +9,7 @@ const defaultValues = {
 context('Auto Save to Local Storage Button', () => {
   beforeEach(() => {
     cy.visit('/');
+    if (defaultValues.autoSave) cy.get('[data-testid=autoSave]').click();
   });
 
   it('should toggle auto save to local storage button', () => {


### PR DESCRIPTION
### Previous Behavior
- changes in default autoSave value leads to test fail

### Current Behavior
- test runs and asserts all the required specification accordingly the autoSave value
